### PR TITLE
Clarify Gondor's model

### DIFF
--- a/docs/scenarios/web.rst
+++ b/docs/scenarios/web.rst
@@ -233,7 +233,8 @@ information.
 
 Gondor has a guide on deploying `Django projects <https://gondor.io/support/django/setup/>`_.
 
-Gondor is run by a small company, and does not have a large number of users.
+Gondor is run by a small company and focuses on helping businesses find success with
+Python and Django.
 
 Templating
 ::::::::::


### PR DESCRIPTION
I belive it's disingenious to only compare
Heroku and Gondor by user base. Based on conversations
with @paltman, I think Gondor aims to be more of a
partner for businesses deploying Django/Pinax applications
than a simple hosting company. I hope this clarifies
their stance.

Including @jtauber @brosner because in no way do I want
to speak for them :)
